### PR TITLE
Handle the case of a missing group session signature key

### DIFF
--- a/java/src/main/java/org/whispersystems/libsignal/groups/state/SenderKeyState.java
+++ b/java/src/main/java/org/whispersystems/libsignal/groups/state/SenderKeyState.java
@@ -98,8 +98,13 @@ public class SenderKeyState {
   }
 
   public ECPrivateKey getSigningKeyPrivate() {
-    return Curve.decodePrivatePoint(senderKeyStateStructure.getSenderSigningKey()
-                                                           .getPrivate().toByteArray());
+    if (senderKeyStateStructure.hasSenderSigningKey() &&
+        senderKeyStateStructure.getSenderSigningKey().hasPrivate()) {
+      return Curve.decodePrivatePoint(senderKeyStateStructure.getSenderSigningKey()
+                                                             .getPrivate().toByteArray());
+    } else {
+      return null;
+    }
   }
 
   public boolean hasSenderMessageKey(int iteration) {


### PR DESCRIPTION
If the library gets into a state where the group session lacks a signature key,
make sure that encrypt fails with an InvalidKeyException. This allows the
code calling encrypt() to handle the condition by clearing the session.

The library can most easily get into this state if you try to encrypt a message from a session
that was previously used for decrypting messages.